### PR TITLE
license: update fsf address

### DIFF
--- a/benchmarks/benchmark_helpers.hpp
+++ b/benchmarks/benchmark_helpers.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #include <iostream>
 #include <stdint.h>

--- a/benchmarks/malloc_aligned.hpp
+++ b/benchmarks/malloc_aligned.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef UTILITIES_MALLOC_ALIGNED_HPP
 #define UTILITIES_MALLOC_ALIGNED_HPP

--- a/benchmarks/perf_counter.hpp
+++ b/benchmarks/perf_counter.hpp
@@ -12,8 +12,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef PERF_COUNTER_HPP
 #define PERF_COUNTER_HPP

--- a/detail/define_macros.hpp
+++ b/detail/define_macros.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_SIMD_DETAIL_DEFINE_MACROS_HPP
 #define NOVA_SIMD_DETAIL_DEFINE_MACROS_HPP

--- a/detail/math.hpp
+++ b/detail/math.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_SIMD_DETAIL_MATH_HPP
 #define NOVA_SIMD_DETAIL_MATH_HPP

--- a/detail/unroll_helpers.hpp
+++ b/detail/unroll_helpers.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_SIMD_DETAIL_UNROLL_HELPERS_HPP
 #define NOVA_SIMD_DETAIL_UNROLL_HELPERS_HPP

--- a/detail/vec_math.hpp
+++ b/detail/vec_math.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_SIMD_DETAIL_VECMATH_HPP
 #define NOVA_SIMD_DETAIL_VECMATH_HPP

--- a/detail/wrap_argument_vector.hpp
+++ b/detail/wrap_argument_vector.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_SIMD_DETAIL_WRAP_ARGUMENT_VECTOR_HPP
 #define NOVA_SIMD_DETAIL_WRAP_ARGUMENT_VECTOR_HPP

--- a/detail/wrap_arguments.hpp
+++ b/detail/wrap_arguments.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef NOVA_SIMD_WRAP_ARGUMENTS_HPP
 #define NOVA_SIMD_WRAP_ARGUMENTS_HPP

--- a/simd_binary_arithmetic.hpp
+++ b/simd_binary_arithmetic.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef SIMD_BINARY_ARITHMETIC_HPP
 #define SIMD_BINARY_ARITHMETIC_HPP

--- a/simd_horizontal_functions.hpp
+++ b/simd_horizontal_functions.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 
 #ifndef SIMD_HORIZONTAL_FUNCTIONS_HPP

--- a/simd_math.hpp
+++ b/simd_math.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef SIMD_MATH_HPP
 #define SIMD_MATH_HPP

--- a/simd_memory.hpp
+++ b/simd_memory.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 
 #ifndef SIMD_MEMORY_HPP

--- a/simd_mix.hpp
+++ b/simd_mix.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 
 #ifndef SIMD_MIX_HPP

--- a/simd_pan.hpp
+++ b/simd_pan.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 
 #ifndef SIMD_PAN_HPP

--- a/simd_peakmeter.hpp
+++ b/simd_peakmeter.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 
 #ifndef SIMD_PEAKMETER_HPP

--- a/simd_ternary_arithmetic.hpp
+++ b/simd_ternary_arithmetic.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 //
 //  implemented as part of nova
 

--- a/simd_unary_arithmetic.hpp
+++ b/simd_unary_arithmetic.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef SIMD_UNARY_ARITHMETIC_HPP
 #define SIMD_UNARY_ARITHMETIC_HPP

--- a/simd_unit_conversion.hpp
+++ b/simd_unit_conversion.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef SIMD_UNIT_CONVERSION_HPP
 #define SIMD_UNIT_CONVERSION_HPP

--- a/simd_unroll_constraints.hpp
+++ b/simd_unroll_constraints.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 
 #ifndef SIMD_UNROLL_CONSTRAINTS_HPP

--- a/simd_utils.hpp
+++ b/simd_utils.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef SIMD_UTILS_HPP
 #define SIMD_UTILS_HPP

--- a/softclip.hpp
+++ b/softclip.hpp
@@ -13,8 +13,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef SIMD_SOFTCLIP_HPP
 #define SIMD_SOFTCLIP_HPP

--- a/vec.hpp
+++ b/vec.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_HPP
 #define VEC_HPP

--- a/vec/vec_altivec.hpp
+++ b/vec/vec_altivec.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_ALTIVEC_HPP
 #define VEC_ALTIVEC_HPP

--- a/vec/vec_avx_double.hpp
+++ b/vec/vec_avx_double.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_AVX_DOUBLE_HPP
 #define VEC_AVX_DOUBLE_HPP

--- a/vec/vec_avx_float.hpp
+++ b/vec/vec_avx_float.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_AVX_FLOAT_HPP
 #define VEC_AVX_FLOAT_HPP

--- a/vec/vec_base.hpp
+++ b/vec/vec_base.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_BASE_HPP
 #define VEC_BASE_HPP

--- a/vec/vec_generic.hpp
+++ b/vec/vec_generic.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_GENERIC_HPP
 #define VEC_GENERIC_HPP

--- a/vec/vec_int_altivec.hpp
+++ b/vec/vec_int_altivec.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_INT_ALTIVEC_HPP
 #define VEC_INT_ALTIVEC_HPP

--- a/vec/vec_int_avx.hpp
+++ b/vec/vec_int_avx.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_AVX_INT_HPP
 #define VEC_AVX_INT_HPP

--- a/vec/vec_int_neon.hpp
+++ b/vec/vec_int_neon.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_INT_NEON_HPP
 #define VEC_INT_NEON_HPP

--- a/vec/vec_int_sse2.hpp
+++ b/vec/vec_int_sse2.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_INT_SSE_HPP
 #define VEC_INT_SSE_HPP

--- a/vec/vec_neon.hpp
+++ b/vec/vec_neon.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_NEON_HPP
 #define VEC_NEON_HPP

--- a/vec/vec_sse.hpp
+++ b/vec/vec_sse.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_SSE_HPP
 #define VEC_SSE_HPP

--- a/vec/vec_sse2.hpp
+++ b/vec/vec_sse2.hpp
@@ -14,8 +14,8 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with this program; see the file COPYING.  If not, write to
-//  the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-//  Boston, MA 02111-1307, USA.
+//  the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+//  Boston, MA 02110-1301, USA.
 
 #ifndef VEC_SSE2_HPP
 #define VEC_SSE2_HPP


### PR DESCRIPTION
License headers are using the old FSF address and this is causing
packaging error with rpmlint: incorrect-fsf-address.